### PR TITLE
Update README.md with correct link to the trunk guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Visit [the MathCAT project page](https://nsoiffer.github.io/MathCAT/) for more i
 
 
 ## Local builds
-To build this and run locally, you need to download and install [trunk](https://docs.trunk.io/docs/install). Then type
+To build this and run locally, you need to download and install [trunk](https://trunkrs.dev/guide/getting-started/installation.html). Then type
 ```
 trunk serve
 ```


### PR DESCRIPTION
I'm guessing the README.md should point to https://trunkrs.dev/guide/getting-started/installation.html instead of https://docs.trunk.io/check/usage

I am wondering if there should be an instruction to also add the WASM build target using
```rustup target add wasm32-unknown-unknown``` to cross-compile the web assembly as the trunk guide says otherwise it will install only the target for the current machine.

